### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     platforms=['any'],
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     install_requires=['requests>=2.0.0'],
     classifiers=[
         'Intended Audience :: Developers',
@@ -21,7 +21,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Unable to be tested with GitHub Actions, and is an EOL Python release.